### PR TITLE
5-client-does-not-effectively-detect-a-disconnected-connection

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,8 @@
 		"ms-vsliveshare.vsliveshare",
 		"notskm.clang-tidy",
 		"cschlosser.doxdocgen",
-		"matepek.vscode-catch2-test-adapter"
+		"matepek.vscode-catch2-test-adapter",
+		"github.vscode-pull-request-github"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,7 +34,7 @@
         {
             "label": "Conan Create",
             "type": "shell",
-            "command": "conan create . --build missing",
+            "command": "conan create .",
             "problemMatcher": []
         },
     ]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,13 @@ set(SOURCE_FILES
     "modbus/server/tcp_session.cpp"
     )
 
+# Extra debugging
+option(CPOOL_TRACE_LOGGING "Extended cpool debug prints" OFF)
+message("-- CPOOL_TRACE_LOGGING is ${CPOOL_TRACE_LOGGING}")
+if(CPOOL_TRACE_LOGGING)
+    add_compile_definitions(CPOOL_TRACE_LOGGING)
+endif(CPOOL_TRACE_LOGGING)
+
 add_library(${TARGET_NAME} STATIC ${SOURCE_FILES})
 
 target_link_libraries(${TARGET_NAME} ${CONAN_LIBS})

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,9 +20,9 @@ class ModbusClientConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "conan.cmake", "conanfile.py", "modbus/*", "test/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cpool/main_b956b06e9403", "boost/1.78.0", "fmt/8.1.1"
+    requires = "cpool/main_92aca5ae6c1c", "boost/1.78.0", "fmt/8.1.1"
     build_requires = "gtest/cci.20210126"
-    options = {"cxx_standard": [20], "build_testing": [True, False], "trace_logging": [True, False]}
+    options = {"cxx_standard": [20,23], "build_testing": [True, False], "trace_logging": [True, False]}
     default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}
     
     def config_options(self):
@@ -39,7 +39,7 @@ class ModbusClientConan(ConanFile):
         return re.sub(r'^v', '', version)
 
     def sanitize_branch(self, branch):
-        return re.sub(r'/', '_', branch)
+        return re.sub(r'/', '_', branch)[:12]
 
     def set_version(self):
         git = tools.Git(folder=self.recipe_folder)

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ class ModbusClientConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "conan.cmake", "conanfile.py", "modbus/*", "test/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cpool/main_92aca5ae6c1c", "boost/1.78.0", "fmt/8.1.1"
+    requires = "cpool/main_ee1c21a42d7a", "boost/1.78.0", "fmt/8.1.1"
     build_requires = "gtest/cci.20210126"
     options = {"cxx_standard": [20,23], "build_testing": [True, False], "trace_logging": [True, False]}
     default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ class ModbusClientConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "conan.cmake", "conanfile.py", "modbus/*", "test/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cpool/main_92aca5ae6c1c", "boost/1.78.0", "fmt/8.1.1"
+    requires = "cpool/main_92aca5ae6c1c", "boost/1.78.0", "fmt/8.1.1", "abseil/20211102.0"
     build_requires = "gtest/cci.20210126"
     options = {"cxx_standard": [20,23], "build_testing": [True, False], "trace_logging": [True, False]}
     default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,8 +22,8 @@ class ModbusClientConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     requires = "cpool/main_b956b06e9403", "boost/1.78.0", "fmt/8.1.1"
     build_requires = "gtest/cci.20210126"
-    options = {"cxx_standard": [20], "build_testing": [True, False]}
-    default_options = {"cxx_standard": 20, "build_testing": True}
+    options = {"cxx_standard": [20], "build_testing": [True, False], "trace_logging": [True, False]}
+    default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}
     
     def config_options(self):
         if self.settings.os == "Windows":
@@ -50,6 +50,7 @@ class ModbusClientConan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["CMAKE_CXX_STANDARD"] = self.options.cxx_standard
         cmake.definitions["BUILD_TESTING"] = self.options.build_testing
+        cmake.definitions["CPOOL_TRACE_LOGGING"] = self.options.trace_logging
         cmake.configure()
         cmake.build()
         cmake.test()

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ class ModbusClientConan(ConanFile):
     exports_sources = ["CMakeLists.txt", "conan.cmake", "conanfile.py", "modbus/*", "test/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cpool/main_92aca5ae6c1c", "boost/1.78.0", "fmt/8.1.1", "abseil/20211102.0"
+    requires = "cpool/main_6c87e8e612ea", "boost/1.78.0", "fmt/8.1.1", "abseil/20211102.0"
     build_requires = "gtest/cci.20210126"
     options = {"cxx_standard": [20,23], "build_testing": [True, False], "trace_logging": [True, False]}
     default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}

--- a/modbus/client/client_config.hpp
+++ b/modbus/client/client_config.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <string>
 
@@ -8,23 +9,29 @@
 namespace modbus {
 
 constexpr uint16_t DEFAULT_CLIENT_MAX_CONNECTIONS = 1;
+constexpr std::chrono::milliseconds DEFAULT_CONNECT_TIMEOUT =
+    std::chrono::seconds(10);
 
 struct client_config {
     std::string host;
     uint16_t port;
     uint16_t max_connections;
+    std::chrono::milliseconds connect_timeout;
     logging_handler_t logging_handler;
 
     client_config()
         : host("127.0.0.1")
         , port(502)
         , max_connections(DEFAULT_CLIENT_MAX_CONNECTIONS)
+        , connect_timeout(DEFAULT_CONNECT_TIMEOUT)
         , logging_handler(null_logging_handler) {}
 
     client_config(std::string host, uint16_t port)
         : host(host)
         , port(port)
-        , max_connections(DEFAULT_CLIENT_MAX_CONNECTIONS) {}
+        , max_connections(DEFAULT_CLIENT_MAX_CONNECTIONS)
+        , connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+        , logging_handler(null_logging_handler) {}
 
     client_config set_host(std::string host) {
         this->host = host;
@@ -38,6 +45,12 @@ struct client_config {
 
     client_config set_max_connections(uint16_t max_connections) {
         this->max_connections = max_connections;
+        return *this;
+    }
+
+    client_config
+    set_connect_timeout(std::chrono::milliseconds connect_timeout) {
+        this->connect_timeout = connect_timeout;
         return *this;
     }
 

--- a/modbus/client/tcp_client.cpp
+++ b/modbus/client/tcp_client.cpp
@@ -30,7 +30,11 @@ uint16_t tcp_client::reserve_transaction_id() { return transaction_id_++; }
 awaitable<read_response_t>
 tcp_client::send_request(const tcp_data_unit& request,
                          std::chrono::milliseconds timeout) {
+    on_log_(modbus::log_level::trace, fmt::format("getting connection - connections {} - idle {}", con_pool_->size(), con_pool_->size_idle()));
     auto connection = co_await con_pool_->get_connection();
+    if(connection == nullptr) {
+        co_return read_response_t(tcp_data_unit(), cpool::error(modbus_client_error_code::stopped));
+    }
 
     // clear buffer to remove responses that may have appeared after a timeout
     auto error = co_await clear_buffer(connection);

--- a/modbus/client/tcp_client.hpp
+++ b/modbus/client/tcp_client.hpp
@@ -69,9 +69,9 @@ class tcp_client {
      * @return awaitable<read_response_t> An awaitable tuple
      * with the response and an error if any
      */
-    [[nodiscard]] awaitable<read_response_t>
-    send_request(const tcp_data_unit& request,
-                 std::chrono::milliseconds timeout = std::chrono::milliseconds::max);
+    [[nodiscard]] awaitable<read_response_t> send_request(
+        const tcp_data_unit& request,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds::max());
 
     /**
      * @brief Sends the request.

--- a/modbus/client/tcp_client.hpp
+++ b/modbus/client/tcp_client.hpp
@@ -71,7 +71,7 @@ class tcp_client {
      */
     [[nodiscard]] awaitable<read_response_t>
     send_request(const tcp_data_unit& request,
-                 std::chrono::milliseconds timeout = 5s);
+                 std::chrono::milliseconds timeout = std::chrono::milliseconds::max);
 
     /**
      * @brief Sends the request.

--- a/modbus/core/error.cpp
+++ b/modbus/core/error.cpp
@@ -40,6 +40,8 @@ struct modbus_client_error_code_category : std::error_category {
                    "checks";
         case modbus_client_error_code::disconnected:
             return "The client was disconnected";
+        case modbus_client_error_code::stopped:
+            return "The client was stopped";
         default:
             return "(unrecognized error)";
         }

--- a/modbus/core/error.cpp
+++ b/modbus/core/error.cpp
@@ -9,6 +9,8 @@ struct modbus_error_code_category : std::error_category {
 
     std::string message(int ev) const override {
         switch (static_cast<modbus_error_code>(ev)) {
+        case modbus_error_code::success:
+            return "Success";
         case modbus_error_code::not_supported:
             return "The requested action is not yet supported";
         case modbus_error_code::internal_error:
@@ -33,7 +35,11 @@ struct modbus_client_error_code_category : std::error_category {
 
     std::string message(int ev) const override {
         switch (static_cast<modbus_client_error_code>(ev)) {
-        case modbus_client_error_code::timeout_expired:
+        case modbus_client_error_code::success:
+            return "Success";
+        case modbus_client_error_code::write_timeout:
+            return "The timeout for sending the request has expired";
+        case modbus_client_error_code::read_timeout:
             return "The timeout for receiving a response has expired";
         case modbus_client_error_code::invalid_response:
             return "A response was received that does not pass verification "
@@ -50,11 +56,13 @@ struct modbus_client_error_code_category : std::error_category {
 
 struct modbus_server_error_code_category : std::error_category {
     const char* name() const noexcept override {
-        return "modbus_server_error_code";
+        return "ModbusServerErrorCode";
     }
 
     std::string message(int ev) const override {
         switch (static_cast<modbus_server_error_code>(ev)) {
+        case modbus_server_error_code::success:
+            return "Success";
         case modbus_server_error_code::exceeded_max_sessions:
             return "The maximum number of sessions were exceeded";
         default:

--- a/modbus/core/error.hpp
+++ b/modbus/core/error.hpp
@@ -5,7 +5,7 @@
 namespace modbus {
 enum class modbus_error_code : uint8_t {
     /// no_error No error has occurred
-    no_error = 0,
+    success = 0,
     /// not_supported The requested action is not yet supported
     not_supported,
     /// An exception was thrown and caught by the program
@@ -21,22 +21,25 @@ enum class modbus_error_code : uint8_t {
 
 enum class modbus_client_error_code : uint8_t {
     /// no_error No error has occurred
-    no_error = 0,
-    /// timeout_expired The timeout for receiving a response has expired
-    timeout_expired,
+    success = 0,
+    /// write_timeout The timeout for writing the request has expired
+    write_timeout,
+    /// read_timeout The timeout for receiving a response has expired
+    read_timeout,
     /// InvalidResponse A response was received that does not pass verification
     /// checks.
     invalid_response,
     /// Disconnected The client was disconnected. This could be from the server
     /// or as a result of a call to disconnect.
     disconnected,
-    /// stopped The client has been stopped. No more requests should be sent to the client.
+    /// stopped The client has been stopped. No more requests should be sent to
+    /// the client.
     stopped
 };
 
 enum class modbus_server_error_code : uint8_t {
     /// no_error No error has occurred
-    no_error = 0,
+    success = 0,
     /// ExceededMaxSessions The maximum number of sessions were exceeded.
     exceeded_max_sessions
 };

--- a/modbus/core/error.hpp
+++ b/modbus/core/error.hpp
@@ -29,7 +29,9 @@ enum class modbus_client_error_code : uint8_t {
     invalid_response,
     /// Disconnected The client was disconnected. This could be from the server
     /// or as a result of a call to disconnect.
-    disconnected
+    disconnected,
+    /// stopped The client has been stopped. No more requests should be sent to the client.
+    stopped
 };
 
 enum class modbus_server_error_code : uint8_t {

--- a/modbus/server/tcp_session_manager.cpp
+++ b/modbus/server/tcp_session_manager.cpp
@@ -22,7 +22,7 @@ awaitable<std::error_code> tcp_session_manager::start(tcp_session_ptr session) {
 
     sessions_.insert(session);
     co_spawn(exec_, session->start(), detached);
-    co_return modbus_server_error_code::no_error;
+    co_return modbus_server_error_code::success;
 }
 
 void tcp_session_manager::stop(tcp_session_ptr session) {


### PR DESCRIPTION
This appears to be a problem with WSL. Additional troubleshooting capabilities have been added to aid in troubleshooting connections in the future. Avoid testing connection cycling on WSL for now.