### PR TITLE
Using a boolean for single coil writes is more intuitive

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -17,14 +17,17 @@ class ModbusClientConan(ConanFile):
     license = "MIT"
     topics = ("modbus", "asio")
     exports = ["LICENSE"]
-    exports_sources = ["CMakeLists.txt", "conan.cmake", "conanfile.py", "modbus/*", "test/*"]
+    exports_sources = ["CMakeLists.txt", "conan.cmake",
+                       "conanfile.py", "modbus/*", "test/*"]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
-    requires = "cpool/main_6c87e8e612ea", "boost/1.78.0", "fmt/8.1.1", "abseil/20211102.0"
+    requires = "cpool/main_23c5e65a0f9b", "boost/1.78.0", "fmt/8.1.1", "abseil/20211102.0"
     build_requires = "gtest/cci.20210126"
-    options = {"cxx_standard": [20,23], "build_testing": [True, False], "trace_logging": [True, False]}
-    default_options = {"cxx_standard": 20, "build_testing": True, "trace_logging": False}
-    
+    options = {"cxx_standard": [20, 23], "build_testing": [
+        True, False], "trace_logging": [True, False]}
+    default_options = {"cxx_standard": 20,
+                       "build_testing": True, "trace_logging": False}
+
     def config_options(self):
         if self.settings.os == "Windows":
             del self.options.fPIC
@@ -33,7 +36,8 @@ class ModbusClientConan(ConanFile):
         if self.settings.os == "Windows" and \
            self.settings.compiler == "Visual Studio" and \
            Version(self.settings.compiler.version.value) < "16":
-            raise ConanInvalidConfiguration("modbus does not support MSVC < 16")
+            raise ConanInvalidConfiguration(
+                "modbus does not support MSVC < 16")
 
     def sanitize_tag(self, version):
         return re.sub(r'^v', '', version)
@@ -59,6 +63,6 @@ class ModbusClientConan(ConanFile):
         self.copy("LICENSE", dst="licenses")
         self.copy("*.hpp", dst="include/modbus", src="modbus")
         self.copy("*.a", dst="lib", keep_path=False)
-        
+
     def package_info(self):
         self.cpp_info.libs = ["modbus"]

--- a/modbus/client/tcp_client.cpp
+++ b/modbus/client/tcp_client.cpp
@@ -60,6 +60,8 @@ tcp_client::send_request(const tcp_data_unit& request,
         on_log_(log_level::trace,
                 fmt::format("setting read timeout of {}ms", timeout.count()));
         connection->expires_after(timeout);
+    } else {
+        connection->expires_never();
     }
 
     auto buf = request.buffer();

--- a/modbus/core/messages/write_single_coil_request.cpp
+++ b/modbus/core/messages/write_single_coil_request.cpp
@@ -4,7 +4,7 @@ namespace modbus {
 
 write_single_coil_request::write_single_coil_request(uint8_t unit_id,
                                                      uint16_t start_address,
-                                                     coil_status_t value) {
+                                                     bool value) {
     this->unit_id = unit_id;
     this->start_address = start_address;
     this->value = value;
@@ -20,7 +20,7 @@ write_single_coil_request::write_single_coil_request(const_buffer_iterator it) {
     value = *it++ << 8;
     value += *it;
 
-    this->value = (coil_status_t)value;
+    this->value = ((coil_status_t)value == coil_status_t::on);
 }
 
 buffer_iterator write_single_coil_request::serialize(buffer_iterator it) const {
@@ -30,7 +30,7 @@ buffer_iterator write_single_coil_request::serialize(buffer_iterator it) const {
     *it++ = start_address & 0x00FF;
 
     // Set coil status
-    *it++ = (value == coil_status_t::on) ? 0xFF : 0x00;
+    *it++ = (value) ? 0xFF : 0x00;
     *it++ = 0x00;
 
     return it;

--- a/modbus/core/messages/write_single_coil_request.hpp
+++ b/modbus/core/messages/write_single_coil_request.hpp
@@ -11,12 +11,12 @@ namespace modbus {
 struct write_single_coil_request {
     uint8_t unit_id;
     uint16_t start_address;
-    coil_status_t value;
+    bool value;
 
     write_single_coil_request() = default;
 
     write_single_coil_request(uint8_t unit_id, uint16_t start_address,
-                              coil_status_t value);
+                              bool value);
 
     write_single_coil_request(const_buffer_iterator it);
 
@@ -28,7 +28,7 @@ struct write_single_coil_request {
 
     static constexpr size_t size() {
         return sizeof(unit_id) + sizeof(uint8_t) + sizeof(start_address) +
-               sizeof(value);
+               sizeof(uint16_t);
     }
 
     buffer_iterator serialize(buffer_iterator it) const;

--- a/modbus/core/messages/write_single_coil_response.cpp
+++ b/modbus/core/messages/write_single_coil_response.cpp
@@ -4,7 +4,7 @@ namespace modbus {
 
 write_single_coil_response::write_single_coil_response(uint8_t unit_id,
                                                        uint16_t start_address,
-                                                       coil_status_t value) {
+                                                       bool value) {
     this->unit_id = unit_id;
     this->start_address = start_address;
     this->value = value;
@@ -21,7 +21,7 @@ write_single_coil_response::write_single_coil_response(
     value = *it++ << 8;
     value += *it;
 
-    this->value = (coil_status_t)value;
+    this->value = ((coil_status_t)value == coil_status_t::on);
 }
 
 buffer_iterator
@@ -32,7 +32,7 @@ write_single_coil_response::serialize(buffer_iterator it) const {
     *it++ = start_address & 0x00FF;
 
     // Set coil status
-    *it++ = (value == coil_status_t::on) ? 0xFF : 0x00;
+    *it++ = (value) ? 0xFF : 0x00;
     *it++ = 0x00;
 
     return it;

--- a/modbus/core/messages/write_single_coil_response.hpp
+++ b/modbus/core/messages/write_single_coil_response.hpp
@@ -15,12 +15,12 @@ namespace modbus {
 struct write_single_coil_response {
     uint8_t unit_id;
     uint16_t start_address;
-    coil_status_t value;
+    bool value;
 
     write_single_coil_response() = default;
 
     write_single_coil_response(uint8_t unit_id, uint16_t start_address,
-                               coil_status_t value);
+                               bool value);
 
     write_single_coil_response(const_buffer_iterator it);
 
@@ -32,7 +32,7 @@ struct write_single_coil_response {
 
     static constexpr size_t size() {
         return sizeof(unit_id) + sizeof(uint8_t) + sizeof(start_address) +
-               sizeof(value);
+               sizeof(uint16_t);
     }
 
     buffer_iterator serialize(buffer_iterator it) const;

--- a/modbus/server/server_helper.hpp
+++ b/modbus/server/server_helper.hpp
@@ -126,13 +126,12 @@ inline buffer_t copy_data_bits(const buffer_t& from,
  * @param coilStatus A value representing On or Off.
  * @param coilAddress The address of the bit to write.
  */
-inline void write_coil(buffer_t& data, coil_status_t coilStatus,
-                       int coilAddress) {
+inline void write_coil(buffer_t& data, bool coilStatus, int coilAddress) {
     int startByte = coilAddress / 8;
     int startBit = coilAddress % 8;
     uint8_t byte = 1 << (startBit);
 
-    if (coilStatus == coil_status_t::on) {
+    if (coilStatus) {
         data[startByte] |= byte; // set bit
     } else {
         data[startByte] &= ~byte; // unset bit

--- a/test/bit_operations_test.cpp
+++ b/test/bit_operations_test.cpp
@@ -52,51 +52,51 @@ TEST(legal_address, write_single_coil) {
     vector<uint8_t> coils, expected;
 
     coils = {0x00, 0x00, 0x00};
-    write_coil(coils, coil_status_t::on, 0);
+    write_coil(coils, true, 0);
     expected = {0x01, 0x00, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::on, 2);
+    write_coil(coils, true, 2);
     expected = {0x05, 0x00, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::on, 8);
+    write_coil(coils, true, 8);
     expected = {0x05, 0x01, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::on, 10);
+    write_coil(coils, true, 10);
     expected = {0x05, 0x05, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::on, 17);
+    write_coil(coils, true, 17);
     expected = {0x05, 0x05, 0x02};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::on, 19);
+    write_coil(coils, true, 19);
     expected = {0x05, 0x05, 0x0A};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 19);
+    write_coil(coils, false, 19);
     expected = {0x05, 0x05, 0x02};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 17);
+    write_coil(coils, false, 17);
     expected = {0x05, 0x05, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 10);
+    write_coil(coils, false, 10);
     expected = {0x05, 0x01, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 8);
+    write_coil(coils, false, 8);
     expected = {0x05, 0x00, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 2);
+    write_coil(coils, false, 2);
     expected = {0x01, 0x00, 0x00};
     EXPECT_EQ(coils, expected);
 
-    write_coil(coils, coil_status_t::off, 0);
+    write_coil(coils, false, 0);
     expected = {0x00, 0x00, 0x00};
     EXPECT_EQ(coils, expected);
 }

--- a/test/e2e_tcp_client_test.cpp
+++ b/test/e2e_tcp_client_test.cpp
@@ -39,9 +39,9 @@ awaitable<void> run_coil_tests(asio::io_context& ctx, tcp_client& client,
     uint16_t start_address = 256;
     uint16_t num_read_coils = 8;
     auto [response, error] = co_await client.send_request(client.create_request(
-        write_single_coil_request{unit_id, start_address, coil_status_t::on}));
+        write_single_coil_request{unit_id, start_address, true}));
 
-    EXPECT_FALSE(error);
+    EXPECT_FALSE(error) << error.message();
     EXPECT_FALSE(response.is_exception());
 
     // read coils

--- a/test/request_test.cpp
+++ b/test/request_test.cpp
@@ -141,18 +141,18 @@ TEST(requests, read_input_reg_request) {
 }
 
 TEST(requests, write_single_coil_request) {
-    write_single_coil_request request{17, 172, coil_status_t::on};
+    write_single_coil_request request{17, 172, true};
 
     EXPECT_EQ(request.unit_id, 17);
     EXPECT_EQ(request.start_address, 172);
-    EXPECT_EQ(request.value, coil_status_t::on);
+    EXPECT_EQ(request.value, true);
     EXPECT_EQ(request.function_code(), function_code_t::write_single_coil);
     EXPECT_EQ(request.type(), message_type::request);
 
     write_single_coil_request eqRequest = request;
-    write_single_coil_request neRequest1{18, 172, coil_status_t::on};
-    write_single_coil_request neRequest2{17, 173, coil_status_t::on};
-    write_single_coil_request neRequest3{17, 172, coil_status_t::off};
+    write_single_coil_request neRequest1{18, 172, true};
+    write_single_coil_request neRequest2{17, 173, true};
+    write_single_coil_request neRequest3{17, 172, false};
 
     EXPECT_EQ(request, eqRequest);
     EXPECT_NE(request, neRequest1);

--- a/test/response_test.cpp
+++ b/test/response_test.cpp
@@ -145,18 +145,18 @@ TEST(responses, read_input_reg_response) {
 }
 
 TEST(responses, write_single_coil_response) {
-    write_single_coil_response response{17, 172, coil_status_t::on};
+    write_single_coil_response response{17, 172, true};
 
     EXPECT_EQ(response.unit_id, 17);
     EXPECT_EQ(response.start_address, 172);
-    EXPECT_EQ(response.value, coil_status_t::on);
+    EXPECT_EQ(response.value, true);
     EXPECT_EQ(response.function_code(), function_code_t::write_single_coil);
     EXPECT_EQ(response.type(), message_type::response);
 
     write_single_coil_response eqResponse = response;
-    write_single_coil_response neResponse1{18, 172, coil_status_t::on};
-    write_single_coil_response neResponse2{17, 173, coil_status_t::on};
-    write_single_coil_response neResponse3{17, 172, coil_status_t::off};
+    write_single_coil_response neResponse1{18, 172, true};
+    write_single_coil_response neResponse2{17, 173, true};
+    write_single_coil_response neResponse3{17, 172, false};
 
     EXPECT_EQ(response, eqResponse);
     EXPECT_NE(response, neResponse1);

--- a/test/tcp_data_unit_test.cpp
+++ b/test/tcp_data_unit_test.cpp
@@ -332,7 +332,7 @@ TEST(tcp_data_unit, read_input_registers_request_two_buffers) {
 }
 
 TEST(tcp_data_unit, write_single_register_request_struct) {
-    write_single_coil_request request{12, 172, coil_status_t::on};
+    write_single_coil_request request{12, 172, true};
     buffer_t data{0x00, 0x05, 0x00, 0x00, 0x00, 0x06,
                   0x0C, 0x05, 0x00, 0xAC, 0xFF, 0x00};
 
@@ -357,7 +357,7 @@ TEST(tcp_data_unit, write_single_register_request_struct) {
 }
 
 TEST(tcp_data_unit, write_single_coil_request_buffer) {
-    write_single_coil_request request{12, 172, coil_status_t::on};
+    write_single_coil_request request{12, 172, true};
     buffer_t data{0x00, 0x05, 0x00, 0x00, 0x00, 0x06,
                   0x0C, 0x05, 0x00, 0xAC, 0xFF, 0x00};
 
@@ -382,7 +382,7 @@ TEST(tcp_data_unit, write_single_coil_request_buffer) {
 }
 
 TEST(tcp_data_unit, write_single_coil_request_two_buffers) {
-    write_single_coil_request request{12, 172, coil_status_t::on};
+    write_single_coil_request request{12, 172, true};
     buffer_t data{0x00, 0x05, 0x00, 0x00, 0x00, 0x06,
                   0x0C, 0x05, 0x00, 0xAC, 0xFF, 0x00};
     buffer_t header{0x00, 0x05, 0x00, 0x00, 0x00, 0x06};

--- a/test/tcp_server_test.cpp
+++ b/test/tcp_server_test.cpp
@@ -179,7 +179,7 @@ struct request_handler {
 
             // Write the coil
             lock_guard<mutex> lock(memorySpaceMutex);
-            if (request.value == coil_status_t::on) {
+            if (request.value == true) {
                 write_coil(memorySpace[dataRow], request.value,
                            request.start_address);
             }
@@ -509,7 +509,7 @@ awaitable<void> run_coil_tests(tcp_client& client) {
     uint16_t start_address = 8;
     uint16_t num_read_coils = 11;
     auto [response, error] = co_await client.send_request(client.create_request(
-        write_single_coil_request{unit_id, start_address, coil_status_t::on}));
+        write_single_coil_request{unit_id, start_address, true}));
 
     EXPECT_FALSE(error);
     EXPECT_FALSE(response.is_exception());


### PR DESCRIPTION
Fixes #10
Fixes issue where some requests that had no timeout could timeout immediately.